### PR TITLE
Fix: Export tensor_to_numpy from utils module

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -15,7 +15,7 @@ from .memory import MemoryManager
 
 from .inference import ModelCache, InferenceWrapper
 
-from .export import ExportUtils
+from .export import ExportUtils, tensor_to_numpy
 
 __all__ = [
     'comfy_to_hwm',
@@ -28,4 +28,5 @@ __all__ = [
     'ModelCache',
     'InferenceWrapper',
     'ExportUtils',
+    'tensor_to_numpy',
 ]


### PR DESCRIPTION
Fixes ImportError when loading nodes in ComfyUI.

The tensor_to_numpy function was defined in utils/export.py but not exported from utils/__init__.py, causing import errors.

Changes:
- utils/__init__.py: Added tensor_to_numpy to imports and __all__