### PR TITLE
Fix: Correct filter order in Gaussian PLY export

### DIFF
--- a/utils/export.py
+++ b/utils/export.py
@@ -262,19 +262,20 @@ class ExportUtils:
             scales = scales[filter_mask]
             quats = quats[filter_mask]
             colors = colors[filter_mask]
+            opacities = opacities[filter_mask]
+
+            # Filter sh if provided
+            if sh is not None:
+                sh = sh[filter_mask]
 
             print(f"  Scale filtering: {filter_mask.sum()}/{num_before} Gaussians below {filter_scale_percentile}th percentile")
 
         num_gaussians = len(means)
 
+        # Reshape opacities after filtering
         if opacities.ndim == 1:
             opacities = opacities.reshape(-1, 1)
-        opacities = opacities[filter_mask] if filter_scale_percentile > 0 and filter_scale_percentile < 100 else opacities
         opacities = opacities.astype(np.float32)
-
-        # Filter sh if provided
-        if sh is not None and filter_scale_percentile > 0 and filter_scale_percentile < 100:
-            sh = sh[filter_mask]
 
         # Build vertex data
         vertex_data = [


### PR DESCRIPTION
Fixes IndexError when applying scale filtering to opacity and SH arrays.

Error:
  IndexError: boolean index did not match indexed array along dimension 0;
  dimension is 1 but corresponding boolean dimension is 4206336

Root cause:
- filter_mask created with original array size (4.2M Gaussians)
- Arrays filtered: means, scales, quats, colors (now ~4M Gaussians)
- opacities reshaped to (-1, 1), then filtered with original mask
- Dimension mismatch: opacities has 1 element, mask has 4.2M

Solution:
1. Apply filter_mask to ALL arrays in same block:
   - means, scales, quats, colors, opacities, sh
2. Perform filtering BEFORE reshaping opacities
3. Move sh filtering into same conditional block

Correct order:
1. Reshape all to standard shapes
2. Create filter_mask based on scales
3. Apply mask to ALL arrays simultaneously
4. Reshape opacities after filtering
5. Build vertex data from filtered arrays

This ensures all arrays have consistent dimensions after filtering.

Success output:
  Scale filtering: 3996019/4206336 Gaussians below 95.0th percentile
  (Removed ~210K outlier Gaussians with unusually large scales)