### PR TITLE
Fix: Reshape opacities before filtering (not after)

### DIFF
--- a/utils/export.py
+++ b/utils/export.py
@@ -245,11 +245,12 @@ class ExportUtils:
 
         num_gaussians = len(means)
 
-        # Ensure correct shapes
+        # Ensure correct shapes BEFORE filtering
         means = means.reshape(-1, 3).astype(np.float32)
         scales = scales.reshape(-1, 3).astype(np.float32)
         quats = quats.reshape(-1, 4).astype(np.float32)
         colors = colors.reshape(-1, 3).astype(np.float32)
+        opacities = opacities.reshape(-1).astype(np.float32)  # Flatten to 1D for filtering
 
         # Filter out Gaussians with large scales (outliers) - IMPROVEMENT FROM OFFICIAL REPO
         if filter_scale_percentile > 0 and filter_scale_percentile < 100:
@@ -272,10 +273,8 @@ class ExportUtils:
 
         num_gaussians = len(means)
 
-        # Reshape opacities after filtering
-        if opacities.ndim == 1:
-            opacities = opacities.reshape(-1, 1)
-        opacities = opacities.astype(np.float32)
+        # Reshape opacities to 2D for PLY export (already filtered and flattened)
+        opacities = opacities.reshape(-1, 1)
 
         # Build vertex data
         vertex_data = [


### PR DESCRIPTION
Fixes IndexError by ensuring opacities is flattened before filter application.

Error (persistent):
  IndexError: boolean index did not match indexed array along dimension 0;
  dimension is 1 but corresponding boolean dimension is 4206336
  at line 265: opacities = opacities[filter_mask]

Root cause:
- opacities array comes in with unknown shape (could be [1], [N,1], [N], etc.)
- Other arrays (means, scales, quats, colors) reshaped at lines 249-252
- opacities NOT reshaped until line 277 (AFTER filtering at line 265)
- Filter applied to un-reshaped array → dimension mismatch

Solution:
1. Reshape opacities to flat 1D array at line 253 (WITH other arrays)
2. Apply filter to flattened opacities at line 265
3. Reshape to 2D (-1, 1) for PLY export at line 277

Correct flow:
  Input: opacities (unknown shape)
  Line 253: Reshape to (-1,) → [4206336]
  Line 265: Apply filter → [~4000000]
  Line 277: Reshape to (-1, 1) for PLY → [~4000000, 1]

All arrays now follow same pattern:
  1. Reshape to standard form
  2. Filter together
  3. Final reshape if needed
  4. Export

This should finally resolve the opacity filtering error.