### PR TITLE
Fix color display and shape mismatch bugs in 3D Gaussian export

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -125,6 +125,17 @@
                     geometry.computeVertexNormals();
                 }
 
+                // Check for color attributes
+                // PLY files can have 'color', 'red/green/blue', or no colors
+                let hasColors = false;
+                if (geometry.attributes.color) {
+                    hasColors = true;
+                } else {
+                    // PLYLoader might store colors differently, check for RGB components
+                    // Some PLY files store as separate red/green/blue attributes
+                    console.log('Geometry attributes:', Object.keys(geometry.attributes));
+                }
+
                 // Center geometry
                 geometry.computeBoundingBox();
                 const center = new THREE.Vector3();
@@ -142,7 +153,7 @@
                 // Create material based on mode
                 pointsMaterial = new THREE.PointsMaterial({
                     size: basePointSize,
-                    vertexColors: geometry.attributes.color ? true : false,
+                    vertexColors: hasColors,
                     sizeAttenuation: true,
                     transparent: mode === 'splat',
                     opacity: mode === 'splat' ? 0.8 : 1.0,
@@ -150,8 +161,9 @@
                 });
 
                 // If no vertex colors, use a default color
-                if (!geometry.attributes.color) {
+                if (!hasColors) {
                     pointsMaterial.color = new THREE.Color(0x00aaff);
+                    console.warn('No color attributes found in PLY file, using default blue color');
                 }
 
                 // Create points
@@ -160,15 +172,15 @@
 
                 // Update file info
                 const vertexCount = geometry.attributes.position.count;
-                const hasColors = geometry.attributes.color ? 'Yes' : 'No';
-                const hasNormals = geometry.attributes.normal ? 'Yes' : 'No';
+                const hasColorsText = hasColors ? 'Yes' : 'No';
+                const hasNormalsText = geometry.attributes.normal ? 'Yes' : 'No';
 
                 fileInfoDiv.innerHTML = `
                     <strong>File:</strong> ${filePath.split('/').pop()}<br>
                     <strong>Mode:</strong> ${mode}<br>
                     <strong>Points:</strong> ${vertexCount.toLocaleString()}<br>
-                    <strong>Colors:</strong> ${hasColors}<br>
-                    <strong>Normals:</strong> ${hasNormals}<br>
+                    <strong>Colors:</strong> ${hasColorsText}<br>
+                    <strong>Normals:</strong> ${hasNormalsText}<br>
                     <strong>Size:</strong> ${maxDim.toFixed(2)} units
                 `;
 


### PR DESCRIPTION
Fixes two critical issues:

1. Color display in web viewer:
   - Add standard PLY color attributes (red, green, blue) to Gaussian PLY export
   - Maintain 3DGS format colors (f_dc_*) for compatibility with 3DGS viewers
   - Convert colors from [0,1] to [0,255] uint8 for standard PLY format
   - Improve color detection in web viewer with better logging

2. IndexError when filtering Gaussians:
   - Fix shape mismatch between sh array and filter_mask
   - Reshape sh array before filtering to ensure first dimension matches means
   - Handle various sh shapes: [1, N, SH_COEFFS, 3], [N, SH_COEFFS, 3], etc.
   - Add warning when sh shape is unexpected

The Gaussian PLY files now contain both standard colors for general viewers (like our web viewer) and 3DGS-specific attributes for specialized viewers.

Resolves: "boolean index did not match indexed array along dimension 0"
Resolves: "solid blue splat" in web viewer