### PR TITLE
Fix 3D viewer orientation and color display issues

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -130,11 +130,33 @@
                 let hasColors = false;
                 if (geometry.attributes.color) {
                     hasColors = true;
+
+                    // Fix color contrast issue in splat mode
+                    // Gaussian splat colors are often in linear space and need gamma correction
+                    if (mode === 'splat') {
+                        const colors = geometry.attributes.color;
+                        const count = colors.count;
+
+                        // Apply gamma correction: linear to sRGB (gamma ≈ 2.2)
+                        for (let i = 0; i < count * 3; i++) {
+                            const linearValue = colors.array[i];
+                            // Use sRGB transfer function
+                            const sRGBValue = linearValue <= 0.0031308
+                                ? 12.92 * linearValue
+                                : 1.055 * Math.pow(linearValue, 1.0 / 2.4) - 0.055;
+                            colors.array[i] = Math.max(0, Math.min(1, sRGBValue));
+                        }
+                        colors.needsUpdate = true;
+                    }
                 } else {
                     // PLYLoader might store colors differently, check for RGB components
                     // Some PLY files store as separate red/green/blue attributes
                     console.log('Geometry attributes:', Object.keys(geometry.attributes));
                 }
+
+                // Flip Y-axis to correct upside-down orientation
+                // (Convert from vision coordinate system to graphics coordinate system)
+                geometry.scale(1, -1, 1);
 
                 // Center geometry
                 geometry.computeBoundingBox();
@@ -172,8 +194,9 @@
 
                 // Update file info
                 const vertexCount = geometry.attributes.position.count;
+                const hasNormals = geometry.attributes.normal !== undefined;
                 const hasColorsText = hasColors ? 'Yes' : 'No';
-                const hasNormalsText = geometry.attributes.normal ? 'Yes' : 'No';
+                const hasNormalsText = hasNormals ? 'Yes' : 'No';
 
                 fileInfoDiv.innerHTML = `
                     <strong>File:</strong> ${filePath.split('/').pop()}<br>


### PR DESCRIPTION
This commit addresses three issues in the interactive 3D viewer:

1. Fix upside-down display: Flip Y-axis to convert from computer vision coordinate system (Y-down) to graphics coordinate system (Y-up)

2. Fix high-contrast colors in splat mode: Apply proper gamma correction (linear to sRGB) for Gaussian splat colors which are stored in linear color space but need to be displayed in sRGB space

3. Fix JavaScript error: Define missing hasNormals variable that was
   causing "ReferenceError: hasNormals is not defined" in console

The viewer now correctly displays point clouds and Gaussian splats with proper orientation and accurate color representation.