### PR TITLE
Fix Gaussian export issues with SH coefficients and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Transform 2D images into 3D worlds using Tencent's HunyuanWorld-Mirror model dir
 [![Python](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/)
 [![CUDA](https://img.shields.io/badge/CUDA-12.x-green.svg)](https://developer.nvidia.com/cuda-downloads)
 
-![HunyuanWorld-Mirror Demo](docs/demo.gif)
-
 ---
 
 ## ✨ Features

--- a/nodes.py
+++ b/nodes.py
@@ -355,6 +355,7 @@ class HWMInference:
             all_gaussian_scales = []
             all_gaussian_quats = []
             all_gaussian_colors = []
+            all_gaussian_sh = []
             all_gaussian_opacities = []
 
             for batch_idx in range(num_batches):
@@ -438,14 +439,14 @@ class HWMInference:
                     if opacities is not None:
                         all_gaussian_opacities.append(opacities)
 
-                    # Extract colors - prefer 'sh' (spherical harmonics) over 'colors'
+                    # Extract colors and spherical harmonics separately
                     sh = extract_param('sh')
                     if sh is not None:
-                        all_gaussian_colors.append(sh)
-                    else:
-                        colors = extract_param('colors')
-                        if colors is not None:
-                            all_gaussian_colors.append(colors)
+                        all_gaussian_sh.append(sh)
+
+                    colors = extract_param('colors')
+                    if colors is not None:
+                        all_gaussian_colors.append(colors)
 
                 # Clear batch memory
                 if num_batches > 1:
@@ -503,7 +504,7 @@ class HWMInference:
                 'quats': concat_tensors(all_gaussian_quats),
                 'colors': concat_tensors(all_gaussian_colors),
                 'opacities': concat_tensors(all_gaussian_opacities),
-                'sh': concat_tensors(all_gaussian_colors),  # sh and colors are the same
+                'sh': concat_tensors(all_gaussian_sh) if len(all_gaussian_sh) > 0 else None,
             }
 
             # Log Gaussian availability

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ safetensors>=0.4.0
 trimesh>=4.0.0
 plyfile>=1.0.0
 open3d>=0.18.0
+pycolmap>=0.6.0
 
 # Visualization
 matplotlib>=3.7.0

--- a/utils/export.py
+++ b/utils/export.py
@@ -345,8 +345,15 @@ class ExportUtils:
         if sh is not None:
             # Flatten SH coefficients
             sh_flat = sh.reshape(num_gaussians, -1).astype(np.float32)
-            for i in range(sh_flat.shape[1]):
-                vertex_data.append((f'f_dc_{i}', sh_flat[:, i]))
+            # First 3 coefficients are DC term (f_dc_0, f_dc_1, f_dc_2)
+            vertex_data.extend([
+                ('f_dc_0', sh_flat[:, 0]),
+                ('f_dc_1', sh_flat[:, 1]),
+                ('f_dc_2', sh_flat[:, 2]),
+            ])
+            # Remaining coefficients are higher-order terms (f_rest_0, f_rest_1, ...)
+            for i in range(3, sh_flat.shape[1]):
+                vertex_data.append((f'f_rest_{i-3}', sh_flat[:, i]))
         else:
             # Simple RGB colors in 3DGS format (normalized [0,1])
             vertex_data.extend([


### PR DESCRIPTION
- Split RGB colors and SH coefficients into separate accumulators in nodes.py to prevent mixing appearance data in gaussian_params
- Fix SH coefficient naming in utils/export.py to use f_dc_* for DC term and f_rest_* for higher-order terms (3DGS standard format)
- Add pycolmap>=0.6.0 to requirements.txt for COLMAP export functionality
- Remove broken docs/demo.gif reference from README.md